### PR TITLE
Add masking helpers and chromosome lookup

### DIFF
--- a/reprise-rs/Cargo.toml
+++ b/reprise-rs/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "reprise-rs"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }

--- a/reprise-rs/src/cli.rs
+++ b/reprise-rs/src/cli.rs
@@ -1,0 +1,82 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+pub struct Config {
+    /// input file name
+    #[arg(long)]
+    pub input: String,
+
+    /// output file name prefix
+    #[arg(long)]
+    pub output: String,
+
+    /// match score
+    #[arg(long, default_value_t = 1)]
+    pub match_score: i32,
+
+    /// mismatch score
+    #[arg(long, default_value_t = -1)]
+    pub mismatch: i32,
+
+    /// gap open score
+    #[arg(long, default_value_t = -5)]
+    pub gap: i32,
+
+    /// gap extension score
+    #[arg(long, default_value_t = -1)]
+    pub gapex: i32,
+
+    /// penalty of incomplete length alignment
+    #[arg(long, default_value_t = -20)]
+    pub cappenalty: i32,
+
+    /// number of mismatches allowed in seed
+    #[arg(long, default_value_t = 0)]
+    pub dist: i32,
+
+    /// maximum extend length
+    #[arg(long, default_value_t = 10000)]
+    pub maxextend: i32,
+
+    /// maximum elements of a repeat family
+    #[arg(long, default_value_t = 100000)]
+    pub maxrepeat: i32,
+
+    /// band size of extension alignment
+    #[arg(long, default_value_t = 5)]
+    pub maxgap: i32,
+
+    /// stop extension after consecutive unchanged scores
+    #[arg(long, default_value_t = 100)]
+    pub stopafter: i32,
+
+    /// minimum consensus length
+    #[arg(long, default_value_t = 50)]
+    pub minlength: i32,
+
+    /// minimum frequency
+    #[arg(long, default_value_t = 3)]
+    pub minfreq: i32,
+
+    /// minimum improvement threshold
+    #[arg(long, default_value_t = 3)]
+    pub minimprovement: i32,
+
+    /// interval to avoid tandem repeat seeds
+    #[arg(long, default_value_t = 500)]
+    pub tandemdist: i32,
+
+    /// number of parallel threads
+    #[arg(long, default_value_t = 1)]
+    pub pa: i32,
+
+    /// enable verbose output
+    #[arg(long, default_value_t = false)]
+    pub verbose: bool,
+
+    /// output masked region files (.masked and .bed)
+    #[arg(long, default_value_t = false)]
+    pub additonalfile: bool,
+}
+

--- a/reprise-rs/src/lib.rs
+++ b/reprise-rs/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod cli;
+pub mod utils;
+pub mod reprise;
+
+pub use reprise::{
+    kmer_frequencies, best_kmer, remove_tandem, remove_masked, mask_by_seed,
+    chrtracer,
+};

--- a/reprise-rs/src/main.rs
+++ b/reprise-rs/src/main.rs
@@ -1,0 +1,23 @@
+use clap::Parser;
+use reprise_rs::{cli, reprise};
+
+fn main() {
+    let config = cli::Config::parse();
+    println!("{:?}", config);
+
+    match reprise::read_fasta(&config.input) {
+        Ok(genome) => {
+            println!("Loaded sequence length: {}", genome.sequence.len());
+            println!("Chromosomes: {}", genome.chrtable.len());
+
+            let k = reprise::default_k(genome.sequence.len(), config.dist as usize);
+            println!("Default k: {}", k);
+
+            if let Some((kmer, count)) = reprise::best_kmer(&genome.sequence, k) {
+                let kmer_str: String = kmer.iter().map(|&b| reprise_rs::utils::num_to_char(b)).collect();
+                println!("Most frequent kmer {} occurs {} times", kmer_str, count);
+            }
+        }
+        Err(e) => eprintln!("Failed to read input: {e}")
+    }
+}

--- a/reprise-rs/src/reprise.rs
+++ b/reprise-rs/src/reprise.rs
@@ -1,0 +1,201 @@
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+
+use crate::utils::{char_to_num, complement};
+
+const PAD_LENGTH: usize = 11000;
+
+#[derive(Debug)]
+pub struct Genome {
+    pub sequence: Vec<u8>,
+    pub chrtable: Vec<(String, usize)>,
+}
+
+pub fn read_fasta(path: &str) -> io::Result<Genome> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+
+    let mut sequence = Vec::new();
+    let mut chrtable = Vec::new();
+    chrtable.push(("unknown".to_string(), 0));
+
+    // initial padding
+    sequence.extend(std::iter::repeat(99u8).take(PAD_LENGTH));
+
+    let mut length = PAD_LENGTH;
+    let mut name: Option<String> = None;
+
+    for line_res in reader.lines() {
+        let line = line_res?;
+        if line.starts_with('>') {
+            // finalize previous chr
+            if name.is_some() {
+                chrtable.push(("padding".to_string(), length));
+                sequence.extend(std::iter::repeat(99u8).take(PAD_LENGTH));
+                length += PAD_LENGTH;
+            }
+            let chrname = line[1..].split_whitespace().next().unwrap_or("").to_string();
+            chrtable.push((chrname.clone(), length));
+            name = Some(chrname);
+        } else {
+            for c in line.trim().chars() {
+                sequence.push(char_to_num(c));
+                length += 1;
+            }
+        }
+    }
+    // final padding
+    chrtable.push(("padding".to_string(), length));
+    sequence.extend(std::iter::repeat(99u8).take(PAD_LENGTH));
+
+    Ok(Genome { sequence, chrtable })
+}
+
+/// Compute log-base-e entropy of a kmer represented as numeric bases (0..3).
+pub fn compute_entropy(kmer: &[u8]) -> f64 {
+    let mut count = [0usize; 4];
+    for &b in kmer {
+        if b < 4 {
+            count[b as usize] += 1;
+        }
+    }
+    let k = kmer.len() as f64;
+    let mut ans = 0.0f64;
+    for &c in &count {
+        if c == 0 {
+            continue;
+        }
+        let y = c as f64 / k;
+        ans += y * y.ln();
+    }
+    ans
+}
+
+/// Compute the default k‑mer length based on genome length and allowed edits.
+pub fn default_k(len: usize, kmerdist: usize) -> usize {
+    const MAX: usize = 40;
+    let mut v = vec![vec![0u128; MAX]; MAX];
+    for i in 0..MAX {
+        v[i][0] = 1;
+        v[i][i] = 1;
+    }
+    for kk in 1..MAX {
+        for j in 1..kk {
+            v[kk][j] = v[kk - 1][j - 1] + v[kk - 1][j];
+        }
+    }
+
+    let mut l = 2usize;
+    while l <= MAX {
+        let mut comb = 0f64;
+        for d in 0..=kmerdist {
+            if d <= l {
+                comb += v[l][d] as f64 * 3f64.powi(d as i32);
+            }
+        }
+        let e = len as f64 * comb / 4f64.powi(l as i32);
+        if e < 1.0 {
+            break;
+        }
+        l += 1;
+    }
+    l + 1
+}
+
+/// Naive suffix array construction used while porting the algorithm.
+pub fn build_suffix_array(seq: &[u8]) -> Vec<usize> {
+    let mut sa: Vec<usize> = (0..seq.len()).collect();
+    sa.sort_by(|&a, &b| seq[a..].cmp(&seq[b..]));
+    sa
+}
+
+/// Find exact kmer occurrences using a suffix array.
+pub fn find_kmer(seq: &[u8], sa: &[usize], query: &[u8]) -> Vec<usize> {
+    let qlen = query.len();
+    sa.iter()
+        .copied()
+        .filter(|&pos| pos + qlen <= seq.len() && &seq[pos..pos + qlen] == query)
+        .collect()
+}
+
+use std::collections::HashMap;
+
+/// Count the occurrences of every k-mer in the sequence.
+pub fn kmer_frequencies(seq: &[u8], k: usize) -> HashMap<Vec<u8>, usize> {
+    let mut counts: HashMap<Vec<u8>, usize> = HashMap::new();
+    if k == 0 || seq.len() < k {
+        return counts;
+    }
+    for window in seq.windows(k) {
+        counts.entry(window.to_vec()).and_modify(|c| *c += 1).or_insert(1);
+    }
+    counts
+}
+
+/// Find the k-mer with the highest frequency.
+pub fn best_kmer(seq: &[u8], k: usize) -> Option<(Vec<u8>, usize)> {
+    kmer_frequencies(seq, k)
+        .into_iter()
+        .max_by_key(|(_, c)| *c)
+}
+
+/// Remove occurrences that are within `dist` bases of the previous one.
+pub fn remove_tandem(occs: &mut Vec<usize>, dist: usize) {
+    occs.sort_unstable();
+    let mut prev: Option<usize> = None;
+    occs.retain(|&occ| {
+        if let Some(p) = prev {
+            if occ < p + dist {
+                false
+            } else {
+                prev = Some(occ);
+                true
+            }
+        } else {
+            prev = Some(occ);
+            true
+        }
+    });
+}
+
+/// Remove occurrences overlapping masked regions.
+pub fn remove_masked(occs: &mut Vec<usize>, mask: &[bool], is_rc: bool, k: usize) {
+    occs.retain(|&occ| {
+        if !is_rc {
+            (0..k).all(|i| !mask[occ + i])
+        } else {
+            (0..k).all(|i| !mask[occ + k - 1 - i])
+        }
+    });
+}
+
+/// Mark seed positions as masked.
+pub fn mask_by_seed(occs: &[usize], mask: &mut [bool], is_rc: bool, k: usize) {
+    if !is_rc {
+        for &o in occs {
+            for i in 0..k {
+                mask[o + i] = true;
+            }
+        }
+    } else {
+        for &o in occs {
+            for i in 0..k {
+                mask[o + k - 1 - i] = true;
+            }
+        }
+    }
+}
+
+/// Return the chromosome name and start index for a sequence position.
+pub fn chrtracer(table: &[(String, usize)], pos: usize) -> (String, usize) {
+    let mut result = table.last().cloned().unwrap_or_else(|| ("".into(), 0));
+    for i in 0..table.len() {
+        if pos < table[i].1 {
+            if i > 0 {
+                result = table[i - 1].clone();
+            }
+            break;
+        }
+    }
+    result
+}

--- a/reprise-rs/src/utils.rs
+++ b/reprise-rs/src/utils.rs
@@ -1,0 +1,38 @@
+pub fn char_to_num(c: char) -> u8 {
+    match c {
+        'A' | 'a' => 0,
+        'C' | 'c' => 1,
+        'G' | 'g' => 2,
+        'T' | 't' => 3,
+        'N' | 'n' => 99,
+        'R' | 'r' | 'Y' | 'y' | 'M' | 'm' |
+        'K' | 'k' | 'W' | 'w' | 'S' | 's' |
+        'B' | 'b' | 'D' | 'd' | 'H' | 'h' |
+        'V' | 'v' => 99,
+        _ => 99,
+    }
+}
+
+pub fn num_to_char(n: u8) -> char {
+    match n {
+        0 => 'A',
+        1 => 'C',
+        2 => 'G',
+        3 => 'T',
+        _ => 'N',
+    }
+}
+
+pub fn complement(n: u8) -> u8 {
+    match n {
+        0 => 3,
+        1 => 2,
+        2 => 1,
+        3 => 0,
+        _ => 99,
+    }
+}
+
+pub fn reverse_complement(seq: &[u8]) -> Vec<u8> {
+    seq.iter().rev().map(|&b| complement(b)).collect()
+}

--- a/reprise-rs/tests/basic.rs
+++ b/reprise-rs/tests/basic.rs
@@ -1,0 +1,67 @@
+use reprise_rs::reprise::{
+    read_fasta, compute_entropy, default_k, build_suffix_array, find_kmer,
+    kmer_frequencies, best_kmer, remove_tandem, remove_masked, mask_by_seed,
+    chrtracer,
+};
+
+#[test]
+fn load_test_fasta() {
+    let genome = read_fasta("../test/tst.fa").expect("read fasta");
+    assert!(!genome.sequence.is_empty());
+}
+
+#[test]
+fn entropy_and_default_k() {
+    let kmer = vec![0u8, 1, 2, 3];
+    let e = compute_entropy(&kmer);
+    let expected = (0.25f64).ln();
+    assert!((e - expected).abs() < 1e-6);
+
+    let k = default_k(1000, 0);
+    assert!(k > 0);
+}
+
+#[test]
+fn suffix_array_search() {
+    let seq = b"ACGACGTT".to_vec();
+    let sa = build_suffix_array(&seq);
+    let occ = find_kmer(&seq, &sa, b"ACG");
+    assert_eq!(occ, vec![0, 3]);
+}
+
+#[test]
+fn kmer_count_and_best() {
+    let seq = b"ACGACGTT".to_vec();
+    let counts = kmer_frequencies(&seq, 3);
+    assert_eq!(counts.get(&b"ACG".to_vec()), Some(&2usize));
+
+    let best = best_kmer(&seq, 3).unwrap();
+    assert_eq!(best.0, b"ACG".to_vec());
+    assert_eq!(best.1, 2);
+}
+
+#[test]
+fn tandem_and_masking() {
+    let mut occs = vec![1usize, 5, 6, 15];
+    remove_tandem(&mut occs, 5);
+    assert_eq!(occs, vec![1, 6, 15]);
+
+    let mask = vec![false, false, true, false, false, false];
+    let mut occs2 = vec![0usize, 1, 4];
+    remove_masked(&mut occs2, &mask, false, 2);
+    assert_eq!(occs2, vec![0, 4]);
+
+    let mut mask_vec = vec![false; 6];
+    mask_by_seed(&occs2, &mut mask_vec, false, 2);
+    assert!(mask_vec[0] && mask_vec[1]);
+    assert!(!mask_vec[2]);
+}
+
+#[test]
+fn chromosome_tracking() {
+    let genome = read_fasta("../test/tst.fa").expect("read fasta");
+    let start = genome.chrtable[1].1;
+    let (chr, pos) = chrtracer(&genome.chrtable, start + 10);
+    assert_eq!(chr, genome.chrtable[1].0);
+    assert_eq!(pos, genome.chrtable[1].1);
+}


### PR DESCRIPTION
## Summary
- port more helpers from C++: tandem removal, mask filters and chromosome tracer
- expose new helpers in the crate
- cover masking utilities with integration tests

## Testing
- `cargo build --quiet` *(fails: failed to download from crates.io)*
- `cargo test --quiet` *(fails: failed to download from crates.io)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684f43f85ac4832f8deeb76a08307054